### PR TITLE
Retain previous sensor value on negative or missing API readings

### DIFF
--- a/custom_components/nsw_air_quality/config_flow.py
+++ b/custom_components/nsw_air_quality/config_flow.py
@@ -5,7 +5,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 
 from .air_qual_controller import fetch_available_sites
-from .const import DOMAIN, CONF_SITE_ID, CONF_SITE_NAME
+from .const import CONF_SITE_ID, CONF_SITE_NAME, DOMAIN
 from .sensor_type import SensorType
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/nsw_air_quality/sensor.py
+++ b/custom_components/nsw_air_quality/sensor.py
@@ -4,19 +4,19 @@ import logging
 from datetime import datetime, timedelta
 
 from homeassistant import exceptions
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, CONCENTRATION_PARTS_PER_MILLION
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 
 from .air_qual_controller import AirQualityController
 from .const import (
-    DOMAIN,
-    SHORT_ATTRIBUTION,
-    MODEL_NAME,
-    CONF_SITE_ID,
-    CONF_CONTROLLER,
     CONCENTRATION_PARTS_PER_HUNDRED_MILLION,
+    CONF_CONTROLLER,
+    CONF_SITE_ID,
+    DOMAIN,
+    MODEL_NAME,
+    SHORT_ATTRIBUTION,
 )
 from .sensor_type import SensorType
 

--- a/custom_components/nsw_air_quality/sensor.py
+++ b/custom_components/nsw_air_quality/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for NSW Air Quality Data """
+"""Sensor platform for NSW Air Quality Data"""
 
 import logging
 from datetime import datetime, timedelta
@@ -21,6 +21,28 @@ from .const import (
 from .sensor_type import SensorType
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _select_value(current_value, sensor_data):
+    """Return the new sensor value, or keep current_value if API data is invalid.
+
+    Keeps the previous value when sensor_data is None, no entry exists for the
+    previous hour, or the reported value is None or negative.
+    """
+    if sensor_data is None:
+        return current_value
+
+    previous_hour = (datetime.now() - timedelta(hours=1)).hour
+    entry = next((item for item in sensor_data if item["Hour"] == previous_hour), None)
+    if entry is None:
+        return current_value
+
+    value = entry.get("Value")
+    if value is None or value < 0:
+        _LOGGER.debug("Invalid API value %s, keeping previous value", value)
+        return current_value
+
+    return value
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -121,14 +143,4 @@ class AirQualitySensor(SensorEntity):
         await self.controller.async_update()
 
         sensor_data = self.controller.site_reading(self._site_id, self._sensor_type)
-        if sensor_data is None:
-            self._attr_native_value = None
-            return
-
-        previous_hour = (datetime.now() - timedelta(hours=1)).hour
-        entry = next((item for item in sensor_data if item["Hour"] == previous_hour), None)
-        self._attr_native_value = entry.get("Value") if entry is not None else None
-
-        if self._attr_native_value is not None and self._attr_native_value < 0:
-            _LOGGER.debug("Negative value for sensor '%s': %f", self._attr_name, entry.get("Value"))
-            self._attr_native_value = 0
+        self._attr_native_value = _select_value(self._attr_native_value, sensor_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Test configuration and fixtures."""
 
-import sys
 import os
+import sys
 from unittest.mock import MagicMock
 
 # Add the custom_components directory to the Python path

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,14 +1,14 @@
 import pytest
 
 from custom_components.nsw_air_quality.const import (
-    DOMAIN,
-    SHORT_ATTRIBUTION,
-    MODEL_NAME,
+    CONCENTRATION_PARTS_PER_HUNDRED_MILLION,
+    CONF_CONTROLLER,
     CONF_SITE_ID,
     CONF_SITE_NAME,
-    CONF_CONTROLLER,
+    DOMAIN,
     HEADERS,
-    CONCENTRATION_PARTS_PER_HUNDRED_MILLION,
+    MODEL_NAME,
+    SHORT_ATTRIBUTION,
 )
 
 

--- a/tests/test_controller_unit.py
+++ b/tests/test_controller_unit.py
@@ -4,9 +4,9 @@ import pytest
 from aioresponses import aioresponses
 
 from custom_components.nsw_air_quality.air_qual_controller import (
+    SITE_DETAILS_ENDPOINT,
     AirQualityController,
     fetch_available_sites,
-    SITE_DETAILS_ENDPOINT,
 )
 from custom_components.nsw_air_quality.sensor_type import SensorType
 

--- a/tests/test_sensor_update.py
+++ b/tests/test_sensor_update.py
@@ -1,0 +1,67 @@
+"""Unit tests for sensor value retention on invalid API responses."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from custom_components.nsw_air_quality.sensor import _select_value
+
+
+def _make_entry(hour, value):
+    return {"Site_Id": 123, "Hour": hour, "Value": value}
+
+
+def _prev_hour():
+    return (datetime.now() - timedelta(hours=1)).hour
+
+
+@pytest.mark.unit
+def test_valid_value_is_returned():
+    """A valid (non-negative) API value replaces the current value."""
+    result = _select_value(10.0, [_make_entry(_prev_hour(), 42.5)])
+    assert result == 42.5
+
+
+@pytest.mark.unit
+def test_keeps_previous_when_sensor_data_is_none():
+    """None sensor data keeps the previous value."""
+    result = _select_value(10.0, None)
+    assert result == 10.0
+
+
+@pytest.mark.unit
+def test_keeps_previous_when_no_entry_for_hour():
+    """Missing entry for the previous hour keeps the previous value."""
+    wrong_hour = (datetime.now() - timedelta(hours=5)).hour
+    result = _select_value(10.0, [_make_entry(wrong_hour, 99.0)])
+    assert result == 10.0
+
+
+@pytest.mark.unit
+def test_keeps_previous_when_value_is_negative():
+    """A negative API value keeps the previous value."""
+    result = _select_value(10.0, [_make_entry(_prev_hour(), -1.0)])
+    assert result == 10.0
+
+
+@pytest.mark.unit
+def test_keeps_previous_when_value_is_none():
+    """A None API value keeps the previous value."""
+    result = _select_value(10.0, [_make_entry(_prev_hour(), None)])
+    assert result == 10.0
+
+
+@pytest.mark.unit
+def test_zero_is_a_valid_value():
+    """Zero is a valid reading and should replace the current value."""
+    result = _select_value(10.0, [_make_entry(_prev_hour(), 0.0)])
+    assert result == 0.0
+
+
+@pytest.mark.unit
+def test_keeps_previous_across_multiple_bad_reads():
+    """The last good value is preserved across consecutive bad reads."""
+    current = 5.5
+    for bad_value in [-1.0, None, -99.0]:
+        current = _select_value(current, [_make_entry(_prev_hour(), bad_value)])
+    assert current == 5.5


### PR DESCRIPTION
## Summary

- Extracts update logic into a `_select_value()` helper in `sensor.py`
  that keeps the last known good value when the API returns a negative
  number, `None`, or no entry for the previous hour
- Zero is treated as a valid reading
- Adds 7 unit tests covering all invalid-value cases

## Test plan

- [ ] All existing unit tests pass (`pytest tests/`)
- [ ] New tests in `tests/test_sensor_update.py` cover: valid value,
  `None` data, missing hour entry, negative value, `None` value,
  zero (valid), and multiple consecutive bad reads
