### PR TITLE
Apply all dependabot dependency updates

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,10 +10,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Create release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         generate_release_notes: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
     - name: Cache pip dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-test.txt') }}
@@ -49,7 +49,7 @@ jobs:
         pytest tests/ -v --cov=custom_components/nsw_air_quality --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v6
       with:
         file: ./coverage.xml
         flags: unittests
@@ -63,10 +63,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,17 +9,17 @@ aiohttp
 aioresponses
 
 # Testing framework
-pytest>=7.0.0
-pytest-asyncio>=0.21.0
-pytest-cov>=4.0.0
-pytest-timeout>=2.1.0
+pytest>=9.0.3
+pytest-asyncio>=1.3.0
+pytest-cov>=7.1.0
+pytest-timeout>=2.4.0
 
 # Code quality tools
 flake8>=6.0.0
 mypy>=1.0.0
 
 # Additional testing utilities
-pytest-mock>=3.10.0
+pytest-mock>=3.15.1
 
 # Type stubs
 types-requests


### PR DESCRIPTION
- Bump pytest>=7.0.0→9.0.3, pytest-asyncio>=0.21.0→1.3.0, pytest-cov>=4.0.0→7.1.0, pytest-timeout>=2.1.0→2.4.0, pytest-mock>=3.10.0→3.15.1
- Bump actions/checkout v4→v6, actions/setup-python v4→v6, actions/cache v3→v5
- Bump codecov/codecov-action v3→v6, softprops/action-gh-release v2→v3

pytest-asyncio 1.x is compatible: pytest.ini already has asyncio_mode=auto and asyncio_default_fixture_loop_scope=function.

https://claude.ai/code/session_01RmUxYJXgfDwkqb2DuPazNE