### PR TITLE
Fix AttributeError in site_reading() when Parameter key is missing or None

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# NSW Air Quality — Developer Notes
+
+## Testing
+
+Use TDD when adding new behaviour or fixing bugs:
+
+1. Write a failing test that reproduces the bug or describes the new behaviour.
+2. Run it to confirm it fails (`/usr/local/bin/python3 -m pytest <test>`).
+3. Make the minimal code change to pass the test.
+4. Run the full unit suite to confirm nothing regressed (`/usr/local/bin/python3 -m pytest -m unit`).
+
+Tests live in `tests/`. Mark each test with `@pytest.mark.unit` (no external calls)
+or `@pytest.mark.integration` (calls the live API).

--- a/custom_components/nsw_air_quality/air_qual_controller.py
+++ b/custom_components/nsw_air_quality/air_qual_controller.py
@@ -72,5 +72,5 @@ class AirQualityController:
             parameter_code = "PM2.5"
 
         site_data = [entry for entry in self._site_data if entry.get("Site_Id") == site_id]
-        sensor_data = [entry for entry in site_data if entry.get("Parameter").get("ParameterCode") == parameter_code]
+        sensor_data = [entry for entry in site_data if (entry.get("Parameter") or {}).get("ParameterCode") == parameter_code]
         return sensor_data

--- a/tests/test_controller_unit.py
+++ b/tests/test_controller_unit.py
@@ -93,3 +93,18 @@ def test_site_reading_with_data():
     # Test non-existent sensor type
     result = controller.site_reading(123, SensorType.CO)
     assert result == []
+
+
+@pytest.mark.unit
+def test_site_reading_skips_entries_with_missing_parameter():
+    """Entries with no Parameter field are silently skipped."""
+    controller = AirQualityController()
+    controller._site_data = [
+        {"Site_Id": 123, "Parameter": {"ParameterCode": "PM2.5"}, "Value": 15.5},
+        {"Site_Id": 123, "Parameter": None, "Value": 99.0},
+        {"Site_Id": 123, "Value": 77.0},  # missing Parameter key entirely
+    ]
+
+    result = controller.site_reading(123, SensorType.PM25)
+    assert len(result) == 1
+    assert result[0]["Value"] == 15.5


### PR DESCRIPTION
entry.get("Parameter") can return None for malformed API responses; chaining
.get("ParameterCode") on None crashes the sensor update for all sensors on the
site. Guard with `(... or {}).get(...)` to silently skip malformed entries.

Test added first (TDD) to confirm the crash before the fix.

https://claude.ai/code/session_01Wf6EvjPXkk8eo2GzET39P6